### PR TITLE
feat: upgrade to tree-sitter-0.24 (including API changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,30 +4,45 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -36,24 +51,46 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.2"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36be3222512d85a112491ae0cc280a38076022414f00b64582da1b7565ffd82"
+checksum = "8ac95b18f0f727aaaa012bd5179a1916706ee3ed071920fdbda738750b0c0bf5"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
 
 [[package]]
+name = "tree-sitter-language"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c199356c799a8945965bb5f2c55b2ad9d9aa7c4b4f6e587fe9dea0bc715e5f9c"
+
+[[package]]
 name = "tree-sitter-toml"
-version = "0.20.0"
+version = "0.24.0"
 dependencies = [
  "cc",
  "tree-sitter",
+ "tree-sitter-language",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-toml"
 description = "TOML grammar for the tree-sitter parsing library"
-version = "0.20.0"
+version = "0.24.0"
 license = "MIT"
 readme = "bindings/rust/README.md"
 keywords = ["incremental", "parsing", "toml"]
@@ -22,7 +22,10 @@ autoexamples = false
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.20"
+tree-sitter-language = "0.1.0"
+
+[dev-dependencies]
+tree-sitter = "0.24"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -22,7 +22,8 @@
 //! edition = "2021"
 //! "#;
 //! let mut parser = Parser::new();
-//! parser.set_language(tree_sitter_toml::language()).expect("Error loading TOML grammar");
+//! let language: tree_sitter::Language = tree_sitter_toml::LANGUAGE.into();
+//! parser.set_language(&language).expect("Error loading TOML grammar");
 //! let parsed = parser.parse(code, None);
 //! # let parsed = parsed.unwrap();
 //! # let root = parsed.root_node();
@@ -34,18 +35,14 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_toml() -> Language;
+    fn tree_sitter_toml() -> *const ();
 }
 
-/// Returns the tree-sitter [Language][] for this grammar.
-///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_toml() }
-}
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_toml) };
 
 /// The source of the TOML tree-sitter grammar description.
 pub const GRAMMAR: &str = include_str!("../../grammar.js");
@@ -63,8 +60,9 @@ mod tests {
     #[test]
     fn can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
+        let language: tree_sitter::Language = super::LANGUAGE.into();
         parser
-            .set_language(super::language())
-            .expect("Error loading TOML  grammar");
+            .set_language(&language)
+            .expect("Error loading TOML grammar");
     }
 }


### PR DESCRIPTION
This PR updates the code to depend on the latest `tree-sitter` crate.

It also updates the API to add the `LANGUAGE` member to match the [other](https://docs.rs/tree-sitter-rust/latest/tree_sitter_rust/constant.LANGUAGE.html) [language](https://docs.rs/tree-sitter-yaml/0.7.0/tree_sitter_yaml/constant.LANGUAGE.html) [crates](https://docs.rs/tree-sitter-json/0.24.8/tree_sitter_json/constant.LANGUAGE.html).